### PR TITLE
Fix svhn test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ On SVHN
 
 
 ## Evaluation of the trained model
-```python test.py --dataset=<cifar10 or svhn> --data_dir=<path_to_data_dir> --log_dir=<path_to_log_dir>```
+On CIFAR-10
 
+```python test.py --dataset=cifar10 --data_dir=./dataset/cifar10/ --log_dir=./log/cifar10aug/```
+
+On SVHN
+
+```python test.py --dataset=svhn --data_dir=./dataset/svhn/ --log_dir=./log/svhnaug/ --top_bn```
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ On SVHN
 ## Evaluation of the trained model
 On CIFAR-10
 
-```python test.py --dataset=cifar10 --data_dir=./dataset/cifar10/ --log_dir=./log/cifar10aug/```
+```python test.py --dataset=cifar10 --data_dir=./dataset/cifar10/ --log_dir=<path_to_log_dir> ```
 
 On SVHN
 
-```python test.py --dataset=svhn --data_dir=./dataset/svhn/ --log_dir=./log/svhnaug/ --top_bn```
+```python test.py --dataset=svhn --data_dir=./dataset/svhn/ --log_dir=<path_to_log_dir> --top_bn```
 


### PR DESCRIPTION
Since top_bn is used for svhn training, it should also be included in test phase. Otherwise, accuracy is rather low on svhn test.